### PR TITLE
Attempt to fix the Build

### DIFF
--- a/Fake/AppVeyor.fsx
+++ b/Fake/AppVeyor.fsx
@@ -7,7 +7,7 @@ open ProcessHelpers
 
 Target "UpdateVersionOnBuildServer" (fun _ ->
     if( Globals.IsAppVeyor ) then
-        tracef "Updating build version for AppVeyor to %s\n" (Globals.BuildVersion.AsString())
-        let allArgs = sprintf "UpdateBuild -Version \"%s\"" (Globals.BuildVersion.AsString())
+        tracef "Updating build version for AppVeyor to %s-%s\n" (Globals.BuildVersion.AsString(), Globals.BuildNumber.AsString())
+        let allArgs = sprintf "UpdateBuild -Version \"%s-%s\"" (Globals.BuildVersion.AsString(), Globals.BuildNumber.AsString())
         ProcessHelpers.Spawn("appveyor", allArgs) |> ignore
 )


### PR DESCRIPTION
Not knowing any F# or AppVeyor, maybe this will work?

It seems like there is a problem when doing appveyor UpdateBuild -Version.
When pushing new commits to a PR, for example, the command will still have the same -Version argument for each commit. So prepending the BuildNumber may be a solution, though I don't know any AppVeyor nor F# so the implementation might be wrong..