### PR TITLE
Modified the DeployPackagesLocally script

### DIFF
--- a/DeployPackagesLocally.sh
+++ b/DeployPackagesLocally.sh
@@ -15,15 +15,15 @@ dotnet pack -p:PackageVersion=$PACKAGEVERSION --include-symbols --include-source
 for f in $PACKAGEDIR/*.symbols.nupkg; do
   mv ${f} ${f/.symbols/}
 done
-# Convert files to lowercase
-for i in $PACKAGEDIR/*; do mv $i `echo $i | tr [:upper:] [:lower:]`; done
 
 for f in $PACKAGEDIR/*.nupkg; do
     echo ""
     packagename=$(basename ${f%.2.0.0-alpha2.1000.nupkg})
     target=$TARGETROOT/$packagename/$PACKAGEVERSION
-
+    
     mkdir -pv $target && cp -v $f $target
+    # Unzip package
     tar -xzf $target/$(basename $f) -C $target
-
+    # Create an empty .sha512 file, or else it won't recognize the package for some reason
+    touch $target/$(basename $f).sha512
 done

--- a/Fake/AppVeyor.fsx
+++ b/Fake/AppVeyor.fsx
@@ -7,7 +7,7 @@ open ProcessHelpers
 
 Target "UpdateVersionOnBuildServer" (fun _ ->
     if( Globals.IsAppVeyor ) then
-        tracef "Updating build version for AppVeyor to %s\n" (Globals.BuildVersion.AsString())
-        let allArgs = sprintf "UpdateBuild -Version \"%s\"" (Globals.BuildVersion.AsString())
+        tracef "Updating build version for AppVeyor to %s-%s\n" (Globals.BuildVersion.AsString(), Globals.BuildNumber.AsString())
+        let allArgs = sprintf "UpdateBuild -Version \"%s-%s\"" (Globals.BuildVersion.AsString(), Globals.BuildNumber.AsString())
         ProcessHelpers.Spawn("appveyor", allArgs) |> ignore
 )


### PR DESCRIPTION
child of #7 

It should now:
- Generate .nupkg files in Build/../Packages (create the folder if needed)
- Move them over to their corresponding folder in ~/.nuget/packages
- Unzip them
- Create an empty .sha512 file in the target folder

How to get on with debugging locally now:
The only prerequisite is that the project that you want to debug locally needs to have a package source feed into ~/.nuget/packages by specifying some Nuget.config file with a package source pointing to that root .nuget/packages folder.

- cd into the folder that has Source and Build in root (For example blah/Runtime/)
- execute ./Build/DeployPackagesLocally.sh
- Make sure that the package references for the packages you want to debug locally are set to use version 1000 (should work with wildcard aswell)
- Try dotnet clean && nuget restore / dotnet restore if it doesn't work 