### PR TITLE
Downgrade Machine.Specifications.Runner.VisualStudio to 2.7.0  

### DIFF
--- a/MSBuild/specs.props
+++ b/MSBuild/specs.props
@@ -7,7 +7,7 @@
         <IsTestProject>true</IsTestProject>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Machine.Specifications.Runner.VisualStudio" Version="2.8.0" />
+        <PackageReference Include="Machine.Specifications.Runner.VisualStudio" Version="2.7.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
         <PackageReference Include="Machine.Specifications" Version="0.12.0" />
         <PackageReference Include="Machine.Specifications.Should" Version="0.11.0" />


### PR DESCRIPTION
Warnings about pulling the .NET 4.6.1 version