### PR TITLE
Revert "lowercasing with tr ... for macOS compatibility"

### DIFF
--- a/DeployPackagesLocally.sh
+++ b/DeployPackagesLocally.sh
@@ -45,13 +45,10 @@ for f in $PACKAGEDIR/*.nupkg; do
 
     pushd $TARGETROOT/$packagename
     find . -maxdepth 2 -type f | while read path; do
-
       dir="$(dirname $path)"
       file="$(basename $path)"
-      low_path=$(echo "$path" | tr [A-Z] [a-z])
-      low_file=$(echo "$file" | tr [A-Z] [a-z])
-      if [ ! "$path" = "$low_path" ]; then
-          mv "$path" "$dir/$low_file"
+      if [ ! "$path" = "${path,,}" ]; then
+          mv "$path" "$dir/${file,,}"
       fi
     done
     find . | while read path; do


### PR DESCRIPTION
Reverts dolittle-tools/DotNET.Build#24

Turns out it didn't quite work. 

```shell
▶ ./Build/DeployPackagesLocally.sh 
Microsoft (R) Build Engine version 16.1.76+g14b0a930a7 for .NET Core
Copyright (C) Microsoft Corporation. All rights reserved.

  Restore completed in 273.22 ms for /Users/einari/Projects/Dolittle/Tools/DotNET.Protobuf/Source/Protobuf.MSBuild/Protobuf.MSBuild.csproj.
  Protobuf.MSBuild -> /Users/einari/Projects/Dolittle/Tools/DotNET.Protobuf/Source/Protobuf.MSBuild/bin/Debug/netstandard2.0/Dolittle.Protobuf.MSBuild.dll
  Successfully created package '/Users/einari/Projects/Dolittle/Tools/DotNET.Protobuf/Packages/Dolittle.Protobuf.MSBuild.1.1000.0.nupkg'.
  Successfully created package '/Users/einari/Projects/Dolittle/Tools/DotNET.Protobuf/Packages/Dolittle.Protobuf.MSBuild.1.1000.0.symbols.nupkg'.

./Build/DeployPackagesLocally.sh: line 33: ${packagename,,}: bad substitution
```