### PR TITLE
Fix nuget calls on linux

### DIFF
--- a/DeployPackagesLocally.sh
+++ b/DeployPackagesLocally.sh
@@ -53,4 +53,8 @@ for f in $PACKAGEDIR/*.nupkg; do
 
 done
 
-nuget init "$PACKAGEDIR" "$TARGETROOT" -Expand -NonInteractive
+if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+    mono /usr/local/bin/nuget.exe init "$PACKAGEDIR" "$TARGETROOT" -Expand -NonInteractive
+else
+    nuget init "$PACKAGEDIR" "$TARGETROOT" -Expand -NonInteractive
+fi

--- a/release_from_local.sh
+++ b/release_from_local.sh
@@ -29,18 +29,20 @@ rm -rf $PWD/Artifacts
 
 dotnet pack -p:PackageVersion=$PACKAGE_VERSION -c release -o $PACKAGEDIR -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg
 
-if [[ "$OSTYPE" == "linux-gnu"* ]]; then
-    NUGET="mono /usr/local/bin/nuget.exe"
-else
-    NUGET="nuget"
-fi
+function push_to_nuget() {
+    if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+        mono /usr/local/bin/nuget.exe push $f -Source https://api.nuget.org/v3/index.json
+    else
+        nuget push $f -Source https://api.nuget.org/v3/index.json
+    fi
+}
 
 for f in $PACKAGEDIR/*.symbols.nupkg
 do
-    eval "$NUGET push $f -Source https://api.nuget.org/v3/index.json"
+    push_to_nuget
 done
 
 for f in $PACKAGEDIR/*.nupkg
 do
-    eval "$NUGET push $f -Source https://api.nuget.org/v3/index.json"
+    push_to_nuget
 done

--- a/release_from_local.sh
+++ b/release_from_local.sh
@@ -29,12 +29,18 @@ rm -rf $PWD/Artifacts
 
 dotnet pack -p:PackageVersion=$PACKAGE_VERSION -c release -o $PACKAGEDIR -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg
 
+if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+    NUGET="mono /usr/local/bin/nuget.exe"
+else
+    NUGET="nuget"
+fi
+
 for f in $PACKAGEDIR/*.symbols.nupkg
 do
-    nuget push $f -Source https://api.nuget.org/v3/index.json   
+    eval "$NUGET push $f -Source https://api.nuget.org/v3/index.json"
 done
 
 for f in $PACKAGEDIR/*.nupkg
 do
-    nuget push $f -Source https://api.nuget.org/v3/index.json   
+    eval "$NUGET push $f -Source https://api.nuget.org/v3/index.json"
 done


### PR DESCRIPTION
Nuget is usually asliased on linux and aliases aren't available in
non-interactive scripts so you have to specify the whole path for the nuget.

Haven't tested these yet.